### PR TITLE
Multiple particld pids

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -1046,12 +1046,12 @@ _get_particld_proc_status(){
     if [ -e $INSTALL_DIR/particld.pid ] ; then
         PARTYD_HASPID=`ps --no-header \`cat $INSTALL_DIR/particld.pid 2>/dev/null\` | wc -l`;
     else
-        PARTYD_HASPID=$(pidof particld)
+        PARTYD_HASPID=$(pidof $INSTALL_DIR/particld)
         if [ $? -gt 0 ]; then
             PARTYD_HASPID=0
         fi
     fi
-    PARTYD_PID=$(pidof particld)
+    PARTYD_PID=$(pidof $INSTALL_DIR/particld)
 }
 
 get_particld_status(){


### PR DESCRIPTION
If you have multiple particld pids running $(pidof particld) would return all the pids instead of just the one we were interested in