### PR TITLE
Prevents smsgMessage processor from starting

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -338,7 +338,7 @@ restart_particld(){
     ok "${messages["done"]}"
 
     pending " --> ${messages["starting_particld"]}"
-    $INSTALL_DIR/particld -daemon 2>&1 >/dev/null
+    $INSTALL_DIR/particld -daemon -smsg=false 2>&1 >/dev/null
     PARTYD_RUNNING=1
     PARTYD_RESPONDING=0
     ok "${messages["done"]}"
@@ -682,7 +682,7 @@ update_particld(){
         # punch it ---------------------------------------------------------------
 
         pending " --> ${messages["launching"]} particld... "
-        $INSTALL_DIR/particld -daemon 2>&1> /dev/null
+        $INSTALL_DIR/particld -daemon -smsg=false 2>&1> /dev/null
         ok "${messages["done"]}"
 
         # probe it ---------------------------------------------------------------

--- a/particl.conf.template
+++ b/particl.conf.template
@@ -1,1 +1,2 @@
 daemon=1
+smsg=0


### PR DESCRIPTION
The purpose for this change is to attempt to prevent the smsge message processor from starting up for a staking node.

As staking nodes could very likely be running on devices with limited storage, it may be necessary to prevent the node from processing and storing smsg messages which could potentially saturate the device's storage.

The change included here simply forces the smsgmessage processor of the daemon **not** start up.