### PR TITLE
Add `curl` to dependencies `install` string

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Particl wallet/daemon management utilities - version 0.11
 
 To install partyman do:
 
-    sudo apt-get install python git unzip pv jq dnsutils netcat-openbsd net-tools
+    sudo apt-get install python git unzip pv jq dnsutils netcat-openbsd net-tools curl
     cd ~ && git clone https://github.com/dasource/partyman
 
 To get the current status of particld, do:


### PR DESCRIPTION
It's used by `./partyman install`.